### PR TITLE
update sys-params to work with new 5G schema in GMT

### DIFF
--- a/examples/spawn_two_buildings/spawn_system_params.json
+++ b/examples/spawn_two_buildings/spawn_system_params.json
@@ -1,159 +1,132 @@
 {
-  "buildings": {
-    "default": {
-      "load_model": "rc",
-      "ets_model": "Indirect Heating and Cooling",
-      "ets_model_parameters": {
-        "indirect": {
-          "heat_flow_nominal": 10000,
-          "heat_exchanger_efficiency": 0.8,
-          "heat_exchanger_primary_pressure_drop": 500,
-          "heat_exchanger_secondary_pressure_drop": 500,
-          "nominal_mass_flow_building": 0.5,
-          "nominal_mass_flow_district": 0.5,
-          "valve_pressure_drop": 6000,
-          "cooling_supply_water_temperature_district": 5,
-          "cooling_supply_water_temperature_building": 7,
-          "heating_supply_water_temperature_district": 55,
-          "heating_supply_water_temperature_building": 50,
-          "delta_temp_hw_district": 19,
-          "delta_temp_hw_building": 14,
-          "delta_temp_chw_building": 4.9,
-          "delta_temp_chw_district": 7.9,
-          "cooling_controller_y_max": 1,
-          "cooling_controller_y_min": 0,
-          "heating_controller_y_max": 1,
-          "heating_controller_y_min": 0
-        }
-      }
-    },
-    "custom": [
-      {
-        "geojson_id": "5a6b99ec37f4de7f94020090",
-        "load_model": "spawn",
-        "load_model_parameters": {
-          "spawn": {
-            "idf_filename": "RefBldgSmallOfficeNew2004_Chicago.idf",
-            "epw_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
-            "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
-            "temp_chw_supply": 7,
-            "temp_chw_return": 12,
-            "temp_hw_supply": 40,
-            "temp_hw_return": 35,
-            "temp_setpoint_cooling": 24,
-            "temp_setpoint_heating": 20,
-            "thermal_zone_names": [
-              "Core_ZN",
-              "Perimeter_ZN_1",
-              "Perimeter_ZN_2",
-              "Perimeter_ZN_3",
-              "Perimeter_ZN_4"
-            ],
-            "zone_nom_htg_loads": [
-              3000,
-              3000,
-              3000,
-              3000,
-              3000
-            ],
-            "zone_nom_clg_loads": [
-              -8750,
-              -8750,
-              -8750,
-              -8750,
-              -8750
-            ]
-          }
-        },
-        "ets_model_parameters": {
-          "indirect": {
-            "heat_flow_nominal": 10000,
-            "heat_exchanger_efficiency": 0.8,
-            "heat_exchanger_primary_pressure_drop": 500,
-            "heat_exchanger_secondary_pressure_drop": 500,
-            "nominal_mass_flow_building": 0.5,
-            "nominal_mass_flow_district": 0.5,
-            "valve_pressure_drop": 6000,
-            "cooling_supply_water_temperature_district": 5,
-            "cooling_supply_water_temperature_building": 7,
-            "heating_supply_water_temperature_district": 55,
-            "heating_supply_water_temperature_building": 50,
-            "delta_temp_hw_district": 19,
-            "delta_temp_hw_building": 14,
-            "delta_temp_chw_building": 4.9,
-            "delta_temp_chw_district": 7.9,
-            "cooling_controller_y_max": 1,
-            "cooling_controller_y_min": 0,
-            "heating_controller_y_max": 1,
-            "heating_controller_y_min": 0
-          }
+  "buildings": [
+    {
+      "geojson_id": "5a6b99ec37f4de7f94020090",
+      "load_model": "spawn",
+      "load_model_parameters": {
+        "spawn": {
+          "idf_filename": "RefBldgSmallOfficeNew2004_Chicago.idf",
+          "epw_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
+          "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
+          "has_liquid_heating": true,
+          "has_electric_heating": false,
+          "has_liquid_cooling": true,
+          "has_electric_cooling": false,
+          "temp_chw_supply": 7,
+          "temp_chw_return": 12,
+          "temp_hw_supply": 40,
+          "temp_hw_return": 35,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20,
+          "thermal_zone_names": [
+            "Core_ZN",
+            "Perimeter_ZN_1",
+            "Perimeter_ZN_2",
+            "Perimeter_ZN_3",
+            "Perimeter_ZN_4"
+          ],
+          "zone_nom_htg_loads": [
+            3000,
+            3000,
+            3000,
+            3000,
+            3000
+          ],
+          "zone_nom_clg_loads": [
+            -8750,
+            -8750,
+            -8750,
+            -8750,
+            -8750
+          ]
         }
       },
-      {
-        "geojson_id": "5a6b99ec37f4de7f94021950",
-        "load_model": "spawn",
-        "load_model_parameters": {
-          "spawn": {
-            "idf_filename": "RefBldgSmallOfficeNew2004_Chicago.idf",
-            "epw_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
-            "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
-            "temp_chw_supply": 7,
-            "temp_chw_return": 12,
-            "temp_hw_supply": 40,
-            "temp_hw_return": 35,
-            "temp_setpoint_cooling": 24,
-            "temp_setpoint_heating": 20,
-            "thermal_zone_names": [
-              "Core_ZN",
-              "Perimeter_ZN_1",
-              "Perimeter_ZN_2",
-              "Perimeter_ZN_3",
-              "Perimeter_ZN_4"
-            ],
-            "zone_nom_htg_loads": [
-              3000,
-              3000,
-              3000,
-              3000,
-              3000
-            ],
-            "zone_nom_clg_loads": [
-              -8750,
-              -8750,
-              -8750,
-              -8750,
-              -8750
-            ]
-          }
-        },
-        "ets_model_parameters": {
-          "indirect": {
-            "heat_flow_nominal": 10000,
-            "heat_exchanger_efficiency": 0.8,
-            "heat_exchanger_primary_pressure_drop": 500,
-            "heat_exchanger_secondary_pressure_drop": 500,
-            "nominal_mass_flow_building": 0.5,
-            "nominal_mass_flow_district": 0.5,
-            "valve_pressure_drop": 6000,
-            "cooling_supply_water_temperature_district": 5,
-            "cooling_supply_water_temperature_building": 7,
-            "heating_supply_water_temperature_district": 55,
-            "heating_supply_water_temperature_building": 50,
-            "delta_temp_hw_district": 19,
-            "delta_temp_hw_building": 14,
-            "delta_temp_chw_building": 4.9,
-            "delta_temp_chw_district": 7.9,
-            "cooling_controller_y_max": 1,
-            "cooling_controller_y_min": 0,
-            "heating_controller_y_max": 1,
-            "heating_controller_y_min": 0
-          }
-        }
+      "ets_model": "Indirect Heating and Cooling",
+      "ets_indirect_parameters": {
+        "heat_flow_nominal": 8000,
+        "heat_exchanger_efficiency": 0.8,
+        "nominal_mass_flow_district": 0.5,
+        "nominal_mass_flow_building": 0.5,
+        "valve_pressure_drop": 6000,
+        "heat_exchanger_secondary_pressure_drop": 500,
+        "heat_exchanger_primary_pressure_drop": 500,
+        "cooling_supply_water_temperature_building": 7,
+        "heating_supply_water_temperature_building": 50,
+        "delta_temp_chw_building": 5,
+        "delta_temp_chw_district": 8,
+        "delta_temp_hw_building": 15,
+        "delta_temp_hw_district": 20,
+        "cooling_controller_y_max": 1,
+        "cooling_controller_y_min": 0,
+        "heating_controller_y_max": 1,
+        "heating_controller_y_min": 0
       }
-    ]
-  },
+    },
+    {
+      "geojson_id": "5a6b99ec37f4de7f94021950",
+      "load_model": "spawn",
+      "load_model_parameters": {
+        "spawn": {
+          "idf_filename": "RefBldgSmallOfficeNew2004_Chicago.idf",
+          "epw_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
+          "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
+          "has_liquid_heating": true,
+          "has_electric_heating": false,
+          "has_liquid_cooling": true,
+          "has_electric_cooling": false,
+          "temp_chw_supply": 7,
+          "temp_chw_return": 12,
+          "temp_hw_supply": 40,
+          "temp_hw_return": 35,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20,
+          "thermal_zone_names": [
+            "Core_ZN",
+            "Perimeter_ZN_1",
+            "Perimeter_ZN_2",
+            "Perimeter_ZN_3",
+            "Perimeter_ZN_4"
+          ],
+          "zone_nom_htg_loads": [
+            3000,
+            3000,
+            3000,
+            3000,
+            3000
+          ],
+          "zone_nom_clg_loads": [
+            -8750,
+            -8750,
+            -8750,
+            -8750,
+            -8750
+          ]
+        }
+      },
+      "ets_model": "Indirect Heating and Cooling",
+      "ets_indirect_parameters": {
+        "heat_flow_nominal": 8000,
+        "heat_exchanger_efficiency": 0.8,
+        "nominal_mass_flow_district": 0.5,
+        "nominal_mass_flow_building": 0.5,
+        "valve_pressure_drop": 6000,
+        "heat_exchanger_secondary_pressure_drop": 500,
+        "heat_exchanger_primary_pressure_drop": 500,
+        "cooling_supply_water_temperature_building": 7,
+        "heating_supply_water_temperature_building": 50,
+        "delta_temp_chw_building": 5,
+        "delta_temp_chw_district": 8,
+        "delta_temp_hw_building": 15,
+        "delta_temp_hw_district": 20,
+        "cooling_controller_y_max": 1,
+        "cooling_controller_y_min": 0,
+        "heating_controller_y_max": 1,
+        "heating_controller_y_min": 0
+      }
+    }
+  ],
   "district_system": {
-    "default": {
+    "fourth_generation": {
       "central_cooling_plant_parameters": {
         "weather_filepath": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
         "heat_flow_nominal": 7999,

--- a/examples/uo_teaser_project/geojson_8_system_params.json
+++ b/examples/uo_teaser_project/geojson_8_system_params.json
@@ -1,357 +1,312 @@
 {
-  "buildings": {
-    "default": {
+  "buildings": [
+    {
+      "geojson_id": "2",
       "load_model": "rc",
-      "ets_model": "Indirect Heating and Cooling",
-      "ets_model_parameters": {
-        "indirect": {
-          "heat_flow_nominal": 10000,
-          "heat_exchanger_efficiency": 0.8,
-          "heat_exchanger_primary_pressure_drop": 500,
-          "heat_exchanger_secondary_pressure_drop": 500,
-          "nominal_mass_flow_building": 0.5,
-          "nominal_mass_flow_district": 0.5,
-          "valve_pressure_drop": 6000,
-          "cooling_supply_water_temperature_district": 5,
-          "cooling_supply_water_temperature_building": 7,
-          "heating_supply_water_temperature_district": 55,
-          "heating_supply_water_temperature_building": 50,
-          "delta_temp_hw_district": 19,
-          "delta_temp_hw_building": 14,
-          "delta_temp_chw_building": 4.9,
-          "delta_temp_chw_district": 7.9,
-          "cooling_controller_y_max": 1,
-          "cooling_controller_y_min": 0,
-          "heating_controller_y_max": 1,
-          "heating_controller_y_min": 0
+      "load_model_parameters": {
+        "rc": {
+          "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
+          "temp_chw_supply": 7,
+          "temp_chw_return": 12,
+          "temp_hw_supply": 40,
+          "temp_hw_return": 35,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20,
+          "fraction_latent_person": 1.24
         }
+      },
+      "ets_model": "Indirect Heating and Cooling",
+      "ets_indirect_parameters": {
+        "heat_flow_nominal": 10000,
+        "heat_exchanger_efficiency": 0.8,
+        "nominal_mass_flow_district": 0.5,
+        "nominal_mass_flow_building": 0.5,
+        "valve_pressure_drop": 6000,
+        "heat_exchanger_secondary_pressure_drop": 500,
+        "heat_exchanger_primary_pressure_drop": 500,
+        "cooling_supply_water_temperature_district": 5,
+        "cooling_supply_water_temperature_building": 7,
+        "heating_supply_water_temperature_district": 55,
+        "heating_supply_water_temperature_building": 50,
+        "delta_temp_chw_building": 5,
+        "delta_temp_chw_district": 8,
+        "delta_temp_hw_building": 15,
+        "delta_temp_hw_district": 20,
+        "cooling_controller_y_max": 1,
+        "cooling_controller_y_min": 0,
+        "heating_controller_y_max": 1,
+        "heating_controller_y_min": 0
       }
     },
-    "custom": [
-      {
-        "geojson_id": "2",
-        "load_model": "rc",
-        "load_model_parameters": {
-          "rc": {
-            "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
-            "temp_chw_supply": 7,
-            "temp_chw_return": 12,
-            "temp_hw_supply": 40,
-            "temp_hw_return": 35,
-            "temp_setpoint_cooling": 24,
-            "temp_setpoint_heating": 20,
-            "fraction_latent_person": 1.24
-          }
-        },
-        "ets_model": "Indirect Heating and Cooling",
-        "ets_model_parameters": {
-          "indirect": {
-            "heat_flow_nominal": 10000,
-            "heat_exchanger_efficiency": 0.8,
-            "nominal_mass_flow_district": 0.5,
-            "nominal_mass_flow_building": 0.5,
-            "valve_pressure_drop": 6000,
-            "heat_exchanger_secondary_pressure_drop": 500,
-            "heat_exchanger_primary_pressure_drop": 500,
-            "cooling_supply_water_temperature_district": 5,
-            "cooling_supply_water_temperature_building": 7,
-            "heating_supply_water_temperature_district": 55,
-            "heating_supply_water_temperature_building": 50,
-            "delta_temp_chw_building": 5,
-            "delta_temp_chw_district": 8,
-            "delta_temp_hw_building": 15,
-            "delta_temp_hw_district": 20,
-            "cooling_controller_y_max": 1,
-            "cooling_controller_y_min": 0,
-            "heating_controller_y_max": 1,
-            "heating_controller_y_min": 0
-          }
+    {
+      "geojson_id": "3",
+      "load_model": "rc",
+      "load_model_parameters": {
+        "rc": {
+          "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
+          "temp_chw_supply": 7,
+          "temp_chw_return": 12,
+          "temp_hw_supply": 40,
+          "temp_hw_return": 35,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20,
+          "fraction_latent_person": 1.24
         }
       },
-      {
-        "geojson_id": "3",
-        "load_model": "rc",
-        "load_model_parameters": {
-          "rc": {
-            "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
-            "temp_chw_supply": 7,
-            "temp_chw_return": 12,
-            "temp_hw_supply": 40,
-            "temp_hw_return": 35,
-            "temp_setpoint_cooling": 24,
-            "temp_setpoint_heating": 20,
-            "fraction_latent_person": 1.24
-          }
-        },
-        "ets_model": "Indirect Heating and Cooling",
-        "ets_model_parameters": {
-          "indirect": {
-            "heat_flow_nominal": 10000,
-            "heat_exchanger_efficiency": 0.8,
-            "nominal_mass_flow_district": 0.5,
-            "nominal_mass_flow_building": 0.5,
-            "valve_pressure_drop": 6000,
-            "heat_exchanger_secondary_pressure_drop": 500,
-            "heat_exchanger_primary_pressure_drop": 500,
-            "cooling_supply_water_temperature_district": 5,
-            "cooling_supply_water_temperature_building": 7,
-            "heating_supply_water_temperature_district": 55,
-            "heating_supply_water_temperature_building": 50,
-            "delta_temp_chw_building": 5,
-            "delta_temp_chw_district": 8,
-            "delta_temp_hw_building": 15,
-            "delta_temp_hw_district": 20,
-            "cooling_controller_y_max": 1,
-            "cooling_controller_y_min": 0,
-            "heating_controller_y_max": 1,
-            "heating_controller_y_min": 0
-          }
-        }
-      },
-      {
-        "geojson_id": "4",
-        "load_model": "rc",
-        "load_model_parameters": {
-          "rc": {
-            "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
-            "temp_chw_supply": 7,
-            "temp_chw_return": 12,
-            "temp_hw_supply": 40,
-            "temp_hw_return": 35,
-            "temp_setpoint_cooling": 24,
-            "temp_setpoint_heating": 20,
-            "fraction_latent_person": 1.24
-          }
-        },
-        "ets_model": "Indirect Heating and Cooling",
-        "ets_model_parameters": {
-          "indirect": {
-            "heat_flow_nominal": 10000,
-            "heat_exchanger_efficiency": 0.8,
-            "nominal_mass_flow_district": 0.5,
-            "nominal_mass_flow_building": 0.5,
-            "valve_pressure_drop": 6000,
-            "heat_exchanger_secondary_pressure_drop": 500,
-            "heat_exchanger_primary_pressure_drop": 500,
-            "cooling_supply_water_temperature_district": 5,
-            "cooling_supply_water_temperature_building": 7,
-            "heating_supply_water_temperature_district": 55,
-            "heating_supply_water_temperature_building": 50,
-            "delta_temp_chw_building": 5,
-            "delta_temp_chw_district": 8,
-            "delta_temp_hw_building": 15,
-            "delta_temp_hw_district": 20,
-            "cooling_controller_y_max": 1,
-            "cooling_controller_y_min": 0,
-            "heating_controller_y_max": 1,
-            "heating_controller_y_min": 0
-          }
-        }
-      },
-      {
-        "geojson_id": "5",
-        "load_model": "rc",
-        "load_model_parameters": {
-          "rc": {
-            "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
-            "temp_chw_supply": 7,
-            "temp_chw_return": 12,
-            "temp_hw_supply": 40,
-            "temp_hw_return": 35,
-            "temp_setpoint_cooling": 24,
-            "temp_setpoint_heating": 20,
-            "fraction_latent_person": 1.24
-          }
-        },
-        "ets_model": "Indirect Heating and Cooling",
-        "ets_model_parameters": {
-          "indirect": {
-            "heat_flow_nominal": 10000,
-            "heat_exchanger_efficiency": 0.8,
-            "nominal_mass_flow_district": 0.5,
-            "nominal_mass_flow_building": 0.5,
-            "valve_pressure_drop": 6000,
-            "heat_exchanger_secondary_pressure_drop": 500,
-            "heat_exchanger_primary_pressure_drop": 500,
-            "cooling_supply_water_temperature_district": 5,
-            "cooling_supply_water_temperature_building": 7,
-            "heating_supply_water_temperature_district": 55,
-            "heating_supply_water_temperature_building": 50,
-            "delta_temp_chw_building": 5,
-            "delta_temp_chw_district": 8,
-            "delta_temp_hw_building": 15,
-            "delta_temp_hw_district": 20,
-            "cooling_controller_y_max": 1,
-            "cooling_controller_y_min": 0,
-            "heating_controller_y_max": 1,
-            "heating_controller_y_min": 0
-          }
-        }
-      },
-      {
-        "geojson_id": "6",
-        "load_model": "rc",
-        "load_model_parameters": {
-          "rc": {
-            "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
-            "temp_chw_supply": 7,
-            "temp_chw_return": 12,
-            "temp_hw_supply": 40,
-            "temp_hw_return": 35,
-            "temp_setpoint_cooling": 24,
-            "temp_setpoint_heating": 20,
-            "fraction_latent_person": 1.24
-          }
-        },
-        "ets_model": "Indirect Heating and Cooling",
-        "ets_model_parameters": {
-          "indirect": {
-            "heat_flow_nominal": 10000,
-            "heat_exchanger_efficiency": 0.8,
-            "nominal_mass_flow_district": 0.5,
-            "nominal_mass_flow_building": 0.5,
-            "valve_pressure_drop": 6000,
-            "heat_exchanger_secondary_pressure_drop": 500,
-            "heat_exchanger_primary_pressure_drop": 500,
-            "cooling_supply_water_temperature_district": 5,
-            "cooling_supply_water_temperature_building": 7,
-            "heating_supply_water_temperature_district": 55,
-            "heating_supply_water_temperature_building": 50,
-            "delta_temp_chw_building": 5,
-            "delta_temp_chw_district": 8,
-            "delta_temp_hw_building": 15,
-            "delta_temp_hw_district": 20,
-            "cooling_controller_y_max": 1,
-            "cooling_controller_y_min": 0,
-            "heating_controller_y_max": 1,
-            "heating_controller_y_min": 0
-          }
-        }
-      },
-      {
-        "geojson_id": "11",
-        "load_model": "rc",
-        "load_model_parameters": {
-          "rc": {
-            "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
-            "temp_chw_supply": 7,
-            "temp_chw_return": 12,
-            "temp_hw_supply": 40,
-            "temp_hw_return": 35,
-            "temp_setpoint_cooling": 24,
-            "temp_setpoint_heating": 20,
-            "fraction_latent_person": 1.24
-          }
-        },
-        "ets_model": "Indirect Heating and Cooling",
-        "ets_model_parameters": {
-          "indirect": {
-            "heat_flow_nominal": 10000,
-            "heat_exchanger_efficiency": 0.8,
-            "nominal_mass_flow_district": 0.5,
-            "nominal_mass_flow_building": 0.5,
-            "valve_pressure_drop": 6000,
-            "heat_exchanger_secondary_pressure_drop": 500,
-            "heat_exchanger_primary_pressure_drop": 500,
-            "cooling_supply_water_temperature_district": 5,
-            "cooling_supply_water_temperature_building": 7,
-            "heating_supply_water_temperature_district": 55,
-            "heating_supply_water_temperature_building": 50,
-            "delta_temp_chw_building": 5,
-            "delta_temp_chw_district": 8,
-            "delta_temp_hw_building": 15,
-            "delta_temp_hw_district": 20,
-            "cooling_controller_y_max": 1,
-            "cooling_controller_y_min": 0,
-            "heating_controller_y_max": 1,
-            "heating_controller_y_min": 0
-          }
-        }
-      },
-      {
-        "geojson_id": "12",
-        "load_model": "rc",
-        "load_model_parameters": {
-          "rc": {
-            "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
-            "temp_chw_supply": 7,
-            "temp_chw_return": 12,
-            "temp_hw_supply": 40,
-            "temp_hw_return": 35,
-            "temp_setpoint_cooling": 24,
-            "temp_setpoint_heating": 20,
-            "fraction_latent_person": 1.24
-          }
-        },
-        "ets_model": "Indirect Heating and Cooling",
-        "ets_model_parameters": {
-          "indirect": {
-            "heat_flow_nominal": 10000,
-            "heat_exchanger_efficiency": 0.8,
-            "nominal_mass_flow_district": 0.5,
-            "nominal_mass_flow_building": 0.5,
-            "valve_pressure_drop": 6000,
-            "heat_exchanger_secondary_pressure_drop": 500,
-            "heat_exchanger_primary_pressure_drop": 500,
-            "cooling_supply_water_temperature_district": 5,
-            "cooling_supply_water_temperature_building": 7,
-            "heating_supply_water_temperature_district": 55,
-            "heating_supply_water_temperature_building": 50,
-            "delta_temp_chw_building": 5,
-            "delta_temp_chw_district": 8,
-            "delta_temp_hw_building": 15,
-            "delta_temp_hw_district": 20,
-            "cooling_controller_y_max": 1,
-            "cooling_controller_y_min": 0,
-            "heating_controller_y_max": 1,
-            "heating_controller_y_min": 0
-          }
-        }
-      },
-      {
-        "geojson_id": "13",
-        "load_model": "rc",
-        "load_model_parameters": {
-          "rc": {
-            "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
-            "temp_chw_supply": 7,
-            "temp_chw_return": 12,
-            "temp_hw_supply": 40,
-            "temp_hw_return": 35,
-            "temp_setpoint_cooling": 24,
-            "temp_setpoint_heating": 20,
-            "fraction_latent_person": 1.24
-          }
-        },
-        "ets_model": "Indirect Heating and Cooling",
-        "ets_model_parameters": {
-          "indirect": {
-            "heat_flow_nominal": 10000,
-            "heat_exchanger_efficiency": 0.8,
-            "nominal_mass_flow_district": 0.5,
-            "nominal_mass_flow_building": 0.5,
-            "valve_pressure_drop": 6000,
-            "heat_exchanger_secondary_pressure_drop": 500,
-            "heat_exchanger_primary_pressure_drop": 500,
-            "cooling_supply_water_temperature_district": 5,
-            "cooling_supply_water_temperature_building": 7,
-            "heating_supply_water_temperature_district": 55,
-            "heating_supply_water_temperature_building": 50,
-            "delta_temp_chw_building": 5,
-            "delta_temp_chw_district": 8,
-            "delta_temp_hw_building": 15,
-            "delta_temp_hw_district": 20,
-            "cooling_controller_y_max": 1,
-            "cooling_controller_y_min": 0,
-            "heating_controller_y_max": 1,
-            "heating_controller_y_min": 0
-          }
-        }
+      "ets_model": "Indirect Heating and Cooling",
+      "ets_indirect_parameters": {
+        "heat_flow_nominal": 10000,
+        "heat_exchanger_efficiency": 0.8,
+        "nominal_mass_flow_district": 0.5,
+        "nominal_mass_flow_building": 0.5,
+        "valve_pressure_drop": 6000,
+        "heat_exchanger_secondary_pressure_drop": 500,
+        "heat_exchanger_primary_pressure_drop": 500,
+        "cooling_supply_water_temperature_district": 5,
+        "cooling_supply_water_temperature_building": 7,
+        "heating_supply_water_temperature_district": 55,
+        "heating_supply_water_temperature_building": 50,
+        "delta_temp_chw_building": 5,
+        "delta_temp_chw_district": 8,
+        "delta_temp_hw_building": 15,
+        "delta_temp_hw_district": 20,
+        "cooling_controller_y_max": 1,
+        "cooling_controller_y_min": 0,
+        "heating_controller_y_max": 1,
+        "heating_controller_y_min": 0
       }
-    ]
-  },
+    },
+    {
+      "geojson_id": "4",
+      "load_model": "rc",
+      "load_model_parameters": {
+        "rc": {
+          "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
+          "temp_chw_supply": 7,
+          "temp_chw_return": 12,
+          "temp_hw_supply": 40,
+          "temp_hw_return": 35,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20,
+          "fraction_latent_person": 1.24
+        }
+      },
+      "ets_model": "Indirect Heating and Cooling",
+      "ets_indirect_parameters": {
+        "heat_flow_nominal": 10000,
+        "heat_exchanger_efficiency": 0.8,
+        "nominal_mass_flow_district": 0.5,
+        "nominal_mass_flow_building": 0.5,
+        "valve_pressure_drop": 6000,
+        "heat_exchanger_secondary_pressure_drop": 500,
+        "heat_exchanger_primary_pressure_drop": 500,
+        "cooling_supply_water_temperature_district": 5,
+        "cooling_supply_water_temperature_building": 7,
+        "heating_supply_water_temperature_district": 55,
+        "heating_supply_water_temperature_building": 50,
+        "delta_temp_chw_building": 5,
+        "delta_temp_chw_district": 8,
+        "delta_temp_hw_building": 15,
+        "delta_temp_hw_district": 20,
+        "cooling_controller_y_max": 1,
+        "cooling_controller_y_min": 0,
+        "heating_controller_y_max": 1,
+        "heating_controller_y_min": 0
+      }
+    },
+    {
+      "geojson_id": "5",
+      "load_model": "rc",
+      "load_model_parameters": {
+        "rc": {
+          "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
+          "temp_chw_supply": 7,
+          "temp_chw_return": 12,
+          "temp_hw_supply": 40,
+          "temp_hw_return": 35,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20,
+          "fraction_latent_person": 1.24
+        }
+      },
+      "ets_model": "Indirect Heating and Cooling",
+      "ets_indirect_parameters": {
+        "heat_flow_nominal": 10000,
+        "heat_exchanger_efficiency": 0.8,
+        "nominal_mass_flow_district": 0.5,
+        "nominal_mass_flow_building": 0.5,
+        "valve_pressure_drop": 6000,
+        "heat_exchanger_secondary_pressure_drop": 500,
+        "heat_exchanger_primary_pressure_drop": 500,
+        "cooling_supply_water_temperature_district": 5,
+        "cooling_supply_water_temperature_building": 7,
+        "heating_supply_water_temperature_district": 55,
+        "heating_supply_water_temperature_building": 50,
+        "delta_temp_chw_building": 5,
+        "delta_temp_chw_district": 8,
+        "delta_temp_hw_building": 15,
+        "delta_temp_hw_district": 20,
+        "cooling_controller_y_max": 1,
+        "cooling_controller_y_min": 0,
+        "heating_controller_y_max": 1,
+        "heating_controller_y_min": 0
+      }
+    },
+    {
+      "geojson_id": "6",
+      "load_model": "rc",
+      "load_model_parameters": {
+        "rc": {
+          "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
+          "temp_chw_supply": 7,
+          "temp_chw_return": 12,
+          "temp_hw_supply": 40,
+          "temp_hw_return": 35,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20,
+          "fraction_latent_person": 1.24
+        }
+      },
+      "ets_model": "Indirect Heating and Cooling",
+      "ets_indirect_parameters": {
+        "heat_flow_nominal": 10000,
+        "heat_exchanger_efficiency": 0.8,
+        "nominal_mass_flow_district": 0.5,
+        "nominal_mass_flow_building": 0.5,
+        "valve_pressure_drop": 6000,
+        "heat_exchanger_secondary_pressure_drop": 500,
+        "heat_exchanger_primary_pressure_drop": 500,
+        "cooling_supply_water_temperature_district": 5,
+        "cooling_supply_water_temperature_building": 7,
+        "heating_supply_water_temperature_district": 55,
+        "heating_supply_water_temperature_building": 50,
+        "delta_temp_chw_building": 5,
+        "delta_temp_chw_district": 8,
+        "delta_temp_hw_building": 15,
+        "delta_temp_hw_district": 20,
+        "cooling_controller_y_max": 1,
+        "cooling_controller_y_min": 0,
+        "heating_controller_y_max": 1,
+        "heating_controller_y_min": 0
+      }
+    },
+    {
+      "geojson_id": "11",
+      "load_model": "rc",
+      "load_model_parameters": {
+        "rc": {
+          "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
+          "temp_chw_supply": 7,
+          "temp_chw_return": 12,
+          "temp_hw_supply": 40,
+          "temp_hw_return": 35,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20,
+          "fraction_latent_person": 1.24
+        }
+      },
+      "ets_model": "Indirect Heating and Cooling",
+      "ets_indirect_parameters": {
+        "heat_flow_nominal": 10000,
+        "heat_exchanger_efficiency": 0.8,
+        "nominal_mass_flow_district": 0.5,
+        "nominal_mass_flow_building": 0.5,
+        "valve_pressure_drop": 6000,
+        "heat_exchanger_secondary_pressure_drop": 500,
+        "heat_exchanger_primary_pressure_drop": 500,
+        "cooling_supply_water_temperature_district": 5,
+        "cooling_supply_water_temperature_building": 7,
+        "heating_supply_water_temperature_district": 55,
+        "heating_supply_water_temperature_building": 50,
+        "delta_temp_chw_building": 5,
+        "delta_temp_chw_district": 8,
+        "delta_temp_hw_building": 15,
+        "delta_temp_hw_district": 20,
+        "cooling_controller_y_max": 1,
+        "cooling_controller_y_min": 0,
+        "heating_controller_y_max": 1,
+        "heating_controller_y_min": 0
+      }
+    },
+    {
+      "geojson_id": "12",
+      "load_model": "rc",
+      "load_model_parameters": {
+        "rc": {
+          "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
+          "temp_chw_supply": 7,
+          "temp_chw_return": 12,
+          "temp_hw_supply": 40,
+          "temp_hw_return": 35,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20,
+          "fraction_latent_person": 1.24
+        }
+      },
+      "ets_model": "Indirect Heating and Cooling",
+      "ets_indirect_parameters": {
+        "heat_flow_nominal": 10000,
+        "heat_exchanger_efficiency": 0.8,
+        "nominal_mass_flow_district": 0.5,
+        "nominal_mass_flow_building": 0.5,
+        "valve_pressure_drop": 6000,
+        "heat_exchanger_secondary_pressure_drop": 500,
+        "heat_exchanger_primary_pressure_drop": 500,
+        "cooling_supply_water_temperature_district": 5,
+        "cooling_supply_water_temperature_building": 7,
+        "heating_supply_water_temperature_district": 55,
+        "heating_supply_water_temperature_building": 50,
+        "delta_temp_chw_building": 5,
+        "delta_temp_chw_district": 8,
+        "delta_temp_hw_building": 15,
+        "delta_temp_hw_district": 20,
+        "cooling_controller_y_max": 1,
+        "cooling_controller_y_min": 0,
+        "heating_controller_y_max": 1,
+        "heating_controller_y_min": 0
+      }
+    },
+    {
+      "geojson_id": "13",
+      "load_model": "rc",
+      "load_model_parameters": {
+        "rc": {
+          "mos_weather_filename": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
+          "temp_chw_supply": 7,
+          "temp_chw_return": 12,
+          "temp_hw_supply": 40,
+          "temp_hw_return": 35,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20,
+          "fraction_latent_person": 1.24
+        }
+      },
+      "ets_model": "Indirect Heating and Cooling",
+      "ets_indirect_parameters": {
+        "heat_flow_nominal": 10000,
+        "heat_exchanger_efficiency": 0.8,
+        "nominal_mass_flow_district": 0.5,
+        "nominal_mass_flow_building": 0.5,
+        "valve_pressure_drop": 6000,
+        "heat_exchanger_secondary_pressure_drop": 500,
+        "heat_exchanger_primary_pressure_drop": 500,
+        "cooling_supply_water_temperature_district": 5,
+        "cooling_supply_water_temperature_building": 7,
+        "heating_supply_water_temperature_district": 55,
+        "heating_supply_water_temperature_building": 50,
+        "delta_temp_chw_building": 5,
+        "delta_temp_chw_district": 8,
+        "delta_temp_hw_building": 15,
+        "delta_temp_hw_district": 20,
+        "cooling_controller_y_max": 1,
+        "cooling_controller_y_min": 0,
+        "heating_controller_y_max": 1,
+        "heating_controller_y_min": 0
+      }
+    }
+  ],
   "district_system": {
-    "default": {
+    "fourth_generation": {
       "central_cooling_plant_parameters": {
         "weather_filepath": "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos",
         "heat_flow_nominal": 7999,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,9 @@ documentation = "https://docs.urbanopt.net/geojson-modelica-translator/"
 
 [tool.poetry.dependencies]
 python = ">=3.7.1, <3.10"
-geojson-modelica-translator = "^0.3.0"
-#geojson-modelica-translator = { path = "../geojson-modelica-translator/", develop = true }
+# geojson-modelica-translator = "^0.3.0"
+# geojson-modelica-translator = { path = "../geojson-modelica-translator/", develop = true }
+geojson-modelica-translator = { git = "https://github.com/urbanopt/geojson-modelica-translator.git", branch = "develop"}
 requests = "^2.24.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This repo depends on the released version of gmt. Once we merge the `add-5g-to-sysparams` branch and release it these tests will pass. Tests pass when run locally.

![Screen Shot 2022-09-01 at 8 42 46 AM](https://user-images.githubusercontent.com/19916206/187942759-f6da0f98-9e05-4af6-8193-db09692fc4b0.png)
